### PR TITLE
Check for duplicates only in relevant ${DIST}

### DIFF
--- a/run_test.sh
+++ b/run_test.sh
@@ -30,7 +30,7 @@ case $CHECK_RESULT in
 		pushd apt-package-whitelist
 		env GITHUB_OAUTH_TOKEN=${GITHUB_OAUTH_TOKEN} ./make_pr.sh -y ${ISSUE_REPO} ${ISSUE_NUMBER} ${DIST}
 		if [ $? -eq $EXIT_NOTHING_TO_COMMIT ]; then
-			COMMIT=$(git blame ubuntu-precise | grep ${PACKAGE} | cut -f1 -d' ' | sort | uniq | head -1)
+			COMMIT=$(git blame ubuntu-${DIST} | grep ${PACKAGE} | cut -f1 -d' ' | sort | uniq | head -1)
 			curl -X POST -sS -H "Content-Type: application/json" -H "Authorization: token ${GITHUB_OAUTH_TOKEN}" \
 				-d "{ \"body\": \"***This is an automated comment.***\r\n\r\nFailed to create a commit and a PR. This usually means that there has been a commit that resolved this request.\r\nInparticular, check https://github.com/travis-ci/apt-package-whitelist/commit/${COMMIT}\" }" \
 				${GITHUB_ISSUES_URL}/comments


### PR DESCRIPTION
This should prevent checker from erroneously flagging requests as duplicates, when a package exists in another ${DIST}