### PR TITLE
Use bash

### DIFF
--- a/add_sources.rb
+++ b/add_sources.rb
@@ -7,8 +7,7 @@ sources = JSON.parse(File.read(File.join(File.dirname($0), 'ubuntu.json')))
 successes = sources.select do |src|
   puts "-------------------\nAdding #{src.inspect}\n"
   if src['key_url']
-    system("curl -sSL #{src['key_url'].untaint.inspect} | sudo -E env LANG=C.UTF-8 apt-key add -") && system("sudo -E env LANG=C.UTF-8 apt-add-repository -y #{src['sourceline'].untaint.inspect}")
-  else
-    system("sudo -E env LANG=C.UTF-8 apt-add-repository -y #{src['sourceline'].untaint.inspect}")
+    next unless system("curl -sSL #{src['key_url'].untaint.inspect} | sudo -E env LANG=C.UTF-8 apt-key add -")
   end
+  system("sudo -E env LANG=C.UTF-8 apt-add-repository -ys #{src['sourceline'].untaint.inspect}")
 end


### PR DESCRIPTION
The intent is to (help) address the issue travis-ci/apt-package-whitelist#3946 I raised earlier among others. The message pointed to a missing source repository for the given package (mine was g++-6).
On further debugging, I found out that without the -s flag `apt-add-repository` adds the `deb-src` entry under /etc/apt/sources.list.d/,,, commented, unavailable for the subsequent apt commands.

In this PR:
- Modified the ruby script to enable adding the source repository along with the binary repository
- Modified the bash script to perform the same action(s) locally (instead of invoking ruby) - use jq for JSON.